### PR TITLE
#7 過去のイベントを表示しない

### DIFF
--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -12,10 +12,12 @@ class User
         $this->db = $db;
     }
 
-    public function events()
+    public function read_events()
     {
 
-        $stmt = $this->db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id 
+        $stmt = $this->db->query("SELECT events.id, events.name, events.start_at, events.end_at, 
+        count(event_attendance.id) AS total_participants FROM events 
+        LEFT JOIN event_attendance ON events.id = event_attendance.event_id 
         where end_at > now() GROUP BY events.id");
         $events = $stmt->fetchAll();
         return $events;

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -1,8 +1,9 @@
 <?php
 
 
-namespace curds;
+namespace cruds;
 
+use PDO;
 
 class User
 {
@@ -10,5 +11,13 @@ class User
     {
         $this->db = $db;
     }
-    
+
+    public function events()
+    {
+
+        $stmt = $this->db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id 
+        where end_at > now() GROUP BY events.id");
+        $events = $stmt->fetchAll();
+        return $events;
+    }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -4,7 +4,7 @@ use cruds\User;
 
 $crud = new User($db);
 
-$events=$crud->events();
+$events=$crud->read_events();
 
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];

--- a/src/index.php
+++ b/src/index.php
@@ -1,8 +1,10 @@
 <?php
 require_once('config.php');
+use cruds\User;
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
-$events = $stmt->fetchAll();
+$crud = new User($db);
+
+$events=$crud->events();
 
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];


### PR DESCRIPTION
## 関連イシュー
#7 

## 検証したこと
データベースあるイベントの内過去の未来のものだけがtoppegeで表示できること。

## エビデンス
![Screenshot (148)](https://user-images.githubusercontent.com/86665694/188756256-fda5ba69-d174-4d54-8bd5-27023a908237.png)
![Screenshot (158)](https://user-images.githubusercontent.com/86665694/189117218-6b3c5b29-877e-4dfd-9ca7-67565057b011.png)



