### PR TITLE
#13 メアド・パスワードを入力してログイン

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -50,10 +50,10 @@ CREATE TABLE admins (
 );
 
 
-INSERT INTO users SET username='武田龍一', email='ryuichitakeda@posse.com', hashed_password=SHA2('takeda',224);
-INSERT INTO users SET username='福場脩真', email='shumafukuba@posse.com', hashed_password=SHA2('fukuba',224);
-INSERT INTO users SET username='古屋美羽', email='miuhuruya@posse.com', hashed_password=SHA2('huruya',224);
-INSERT INTO users SET username='中澤和貴', email='kazukinakazawa@posse.com', hashed_password=SHA2('nakazawa',224);
+INSERT INTO users SET username='武田龍一', email='ryuichitakeda@posse.com', hashed_password=SHA1('takeda');
+INSERT INTO users SET username='福場脩真', email='shumafukuba@posse.com', hashed_password=SHA1('fukuba');
+INSERT INTO users SET username='古屋美羽', email='miuhuruya@posse.com', hashed_password=SHA1('huruya');
+INSERT INTO users SET username='中澤和貴', email='kazukinakazawa@posse.com', hashed_password=SHA1('nakazawa');
 
 
 INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -51,10 +51,6 @@ if($_SERVER['REQUEST_METHOD'] == 'POST'){
         <?php if($error == 'failed'):?>
           <p>ログイン失敗しました</p>
         <?php endif?>
-        <label class="inline-block mb-6">
-          <input type="checkbox" checked>
-          <span class="text-sm">ログイン状態を保持する</span>
-        </label>
         <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
       <div class="text-center text-xs text-gray-400 mt-6">

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -1,3 +1,27 @@
+<?php
+require_once($_SERVER['DOCUMENT_ROOT'] . '/config.php');
+use modules\auth\User as Auth;
+use cruds\User as Cruds;
+
+$auth = new Auth($db);
+$cruds = new Cruds($db);
+
+$error = '';
+
+if($_SERVER['REQUEST_METHOD'] == 'POST'){
+  if(isset($_POST['email']) && isset($_POST['password'])){
+    $login = $auth->login($_POST['email'], $_POST['password']);
+    if($login){
+      header('Location: http://' . $_SERVER['HTTP_HOST'] . '/index.php');
+      exit();
+    }else{
+      $error = 'failed';
+    }
+  }
+}
+
+?>
+
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -21,9 +45,12 @@
   <main class="bg-gray-100 h-screen">
     <div class="w-full mx-auto py-10 px-5">
       <h2 class="text-md font-bold mb-5">ログイン</h2>
-      <form action="/" method="POST">
-        <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3">
-        <input type="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">
+      <form action="" method="POST">
+        <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3" name="email">
+        <input type="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3" name="password">
+        <?php if($error == 'failed'):?>
+          <p>ログイン失敗しました</p>
+        <?php endif?>
         <label class="inline-block mb-6">
           <input type="checkbox" checked>
           <span class="text-sm">ログイン状態を保持する</span>

--- a/src/config.php
+++ b/src/config.php
@@ -4,6 +4,8 @@ define('DB_USER', getenv('MYSQL_USER'));
 define('DB_PASS', getenv('MYSQL_PASSWORD'));
 define('SITE_URL', 'http://' . $_SERVER['HTTP_HOST']);
 
+session_start();
+
 use database\Database;
 
 // クラスを自動ロードする関数

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -23,4 +23,11 @@ class User
         $events = $stmt->fetchAll();
         return $events;
     }
+    public function get_user($email)
+    {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE users.email=:email');
+        $stmt->bindValue(':email', $email, \PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->fetch();
+    }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -2,6 +2,11 @@
 require_once('config.php');
 use cruds\User;
 
+use modules\auth\User as Auth;
+$auth = new Auth($db);
+
+$auth->validate();
+
 $crud = new User($db);
 
 $events=$crud->read_events();

--- a/src/modules/auth/User.php
+++ b/src/modules/auth/User.php
@@ -21,4 +21,12 @@ class User{
             return false;
         }
     }
+
+    public function validate()
+    {
+        if(!isset($_SESSION['user']['id'])){
+            header("Location: http://" . $_SERVER['HTTP_HOST'] . "/auth/login/index.php");
+            exit();
+        }
+    }
 }

--- a/src/modules/auth/User.php
+++ b/src/modules/auth/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace modules\auth;
+use cruds\User as Cruds;
+
+class User{
+    
+    public function __construct(\PDO $db)
+    {
+        $this->cruds = new Cruds($db);
+    }
+
+    public function login($email,$password)
+    {
+        $user = $this->cruds->get_user($email);
+        $user_password = $user['hashed_password'];
+        if(sha1($password) === $user_password){
+            $_SESSION['user']['id'] = $user['id'];
+            return true;
+        }else{
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 関連イシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/13

## 検証したこと
ユーザーが入力したメアドをもとにユーザー情報をDBから抽出し、抽出されたパスワード(ハッシュ化済み)と入力したパスワードをハッシュ化したものを正誤判定しました。一致していたらセッション情報を作り、トップページに遷移し、一致していなかったらページ遷移はせずに「ログイン失敗しました」を表示させることを確認しました。またトップページにアクセスしたときのログイン状態の確認はバリデーションによって行いました。

## エビデンス

<img width="1248" alt="2022-09-07" src="https://user-images.githubusercontent.com/86541032/188760379-2e39d29b-a3dd-4c4e-a451-8a0c352577b8.png">
<img width="1248" alt="2022-09-07 (1)" src="https://user-images.githubusercontent.com/86541032/188760410-a5f991ab-b15a-465f-add5-029e451ebc81.png">
<img width="1248" alt="2022-09-07 (2)" src="https://user-images.githubusercontent.com/86541032/188760418-31aa2179-876d-41a7-8ffc-e2e184108a06.png">
