### PR TITLE
#10 ボタンによってさ全て、参加、不参加、未回答のイベントが表示される

### DIFF
--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -52,7 +52,8 @@ class User
         $stmt = $this->db->prepare
         ("SELECT * FROM events WHERE id NOT IN(
         SELECT event_id FROM event_attendance 
-        WHERE user_id = 1)
+        WHERE user_id = :user_id)
+        and end_at > now()
         ");       
         $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
         $stmt->execute();

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -46,4 +46,17 @@ class User
         $attendant_events = $stmt->fetchAll();
         return $attendant_events;
     }
+
+    public function read_unanswered_events($user_id)
+    {
+        $stmt = $this->db->prepare
+        ("SELECT * FROM events WHERE id NOT IN(
+        SELECT event_id FROM event_attendance 
+        WHERE user_id = 1)
+        ");       
+        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt->execute();
+        $unanswered_events = $stmt->fetchAll();
+        return $unanswered_events;
+    }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -138,20 +138,20 @@ function get_day_of_week($w)
     <?php if ($is_answered == '1') { ?>
       <script>
         changedButtonColor(3);
-      </script>;
+      </script>
   <?php }else if($is_attendance == '1') { ?>
     <script>
       changedButtonColor(1);
-    </script>;
+    </script>
   <?php } else if($is_attendance == '0'){ ?>
     <script>
       changedButtonColor(2);
-    </script>;
+    </script>
   <?php } else { ?>
     <script>
       changedButtonColor(0);
-    </script>;
-  <?php }; ?>
+    </script>
+  <?php } ?>
 </body>
 
 </html>

--- a/src/index.php
+++ b/src/index.php
@@ -6,8 +6,7 @@ use modules\auth\User as Auth;
 $auth = new Auth($db);
 
 $auth->validate();
-// $user_id = $_SESSION['user']['id'];
-$user_id = 3;
+$user_id = $_SESSION['user']['id'];
 
 $crud = new User($db);
 
@@ -19,6 +18,7 @@ if (isset($_GET['is_attendance'])) {
 }
 if (isset($_GET['is_answered'])) {
   $is_answered = $_GET['is_answered'];
+  $events = $crud->read_unanswered_events($user_id, $is_attendance);
 }
 
 function get_day_of_week($w)

--- a/src/index.php
+++ b/src/index.php
@@ -15,11 +15,7 @@ $events=$crud->read_events();
 
 if (isset($_GET['is_attendance'])) {
   $is_attendance = $_GET['is_attendance'];
-
-  // boolval()
-  echo ((bool)$is_attendance);
-  // echo $attendance;
-  $events = $crud->read_attendance_events($user_id, boolval($is_attendance));
+  $events = $crud->read_attendance_events($user_id, $is_attendance);
 }
 if (isset($_GET['is_answered'])) {
   $is_answered = $_GET['is_answered'];
@@ -63,9 +59,9 @@ function get_day_of_week($w)
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div id="attendance_button_container" class="flex">
           <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
-          <a href="index.php?is_attendance=true" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="index.php?is_attendance=false" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="index.php?is_answered=true" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+          <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+          <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+          <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
         </div>
       </div>
       <div id="events-list">
@@ -139,15 +135,15 @@ function get_day_of_week($w)
 
     }
   </script>
-    <?php if ($is_answered == 'true') { ?>
+    <?php if ($is_answered == '1') { ?>
       <script>
         changedButtonColor(3);
       </script>;
-  <?php }else if($is_attendance == 'true') { ?>
+  <?php }else if($is_attendance == '1') { ?>
     <script>
       changedButtonColor(1);
     </script>;
-  <?php } else if($is_attendance == 'false'){ ?>
+  <?php } else if($is_attendance == '0'){ ?>
     <script>
       changedButtonColor(2);
     </script>;

--- a/src/index.php
+++ b/src/index.php
@@ -6,18 +6,23 @@ use modules\auth\User as Auth;
 $auth = new Auth($db);
 
 $auth->validate();
-$user_id = $_SESSION['user']['id'];
+// $user_id = $_SESSION['user']['id'];
+$user_id = 3;
 
 $crud = new User($db);
 
 $events=$crud->read_events();
 
-if (isset($_GET['attendance_id'])) {
-  $attendance_id = $_GET['attendance_id'];
+if (isset($_GET['is_attendance'])) {
+  $is_attendance = $_GET['is_attendance'];
+
+  // boolval()
+  echo ((bool)$is_attendance);
+  // echo $attendance;
+  $events = $crud->read_attendance_events($user_id, boolval($is_attendance));
 }
-if ($attendance_id == 1) {
-  $is_attendance = true;
-  $events = $crud->read_attendance_events($user_id, $is_attendance);
+if (isset($_GET['is_answered'])) {
+  $is_answered = $_GET['is_answered'];
 }
 
 function get_day_of_week($w)
@@ -58,9 +63,9 @@ function get_day_of_week($w)
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div id="attendance_button_container" class="flex">
           <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
-          <a href="index.php?attendance_id=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+          <a href="index.php?is_attendance=true" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+          <a href="index.php?is_attendance=false" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+          <a href="index.php?is_answered=true" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
         </div>
       </div>
       <div id="events-list">
@@ -134,9 +139,17 @@ function get_day_of_week($w)
 
     }
   </script>
-  <?php if ($attendance_id == 1) { ?>
+    <?php if ($is_answered == 'true') { ?>
+      <script>
+        changedButtonColor(3);
+      </script>;
+  <?php }else if($is_attendance == 'true') { ?>
     <script>
       changedButtonColor(1);
+    </script>;
+  <?php } else if($is_attendance == 'false'){ ?>
+    <script>
+      changedButtonColor(2);
     </script>;
   <?php } else { ?>
     <script>


### PR DESCRIPTION
## 関連イシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/10

## 検証したこと
押したボタンが全て、参加、不参加、未回答によってsortできること。

## エビデンス

![Screenshot (152)](https://user-images.githubusercontent.com/86665694/188806733-990bb1ef-94df-4ac2-a468-8c7cdb33b8a2.png)
![Screenshot (153)](https://user-images.githubusercontent.com/86665694/188806747-77589b4f-dce9-424b-97d5-53d89a5e919e.png)
![Screenshot (154)](https://user-images.githubusercontent.com/86665694/188806753-f807a351-123b-40c4-93c7-07bd33ef600a.png)
![Screenshot (155)](https://user-images.githubusercontent.com/86665694/188806766-d8abb6f5-026b-4581-a38a-c84c4f445ce0.png)
