### PR TITLE
#27 管理画面からイベント名、開催日時、イベント内容を登録出来るようにする

### DIFF
--- a/src/admin/add_event.php
+++ b/src/admin/add_event.php
@@ -1,0 +1,48 @@
+<?php
+
+if ($_SERVER['HTTP_METHOD'] === 'POST')
+{
+    $event_name = $_REQUEST['event_name'];
+    $start_at = $_REQUEST['start_at'];
+    $end_at = $_REQUEST['end_at'];
+    $detail = $_REQUEST['detail'];
+    $error = array(
+        'event_name' => '',
+        'start_at' => '',
+        'end_at' => '',
+    );
+    if (!isset($event_name)){
+        $error['event_name'] = 'blank';
+    }
+    if (!isset($start_at)){
+        $error['start_at'] = 'blank';
+    }
+    if (!isset($end_at)){
+        $error['end_at'] = 'blank';
+    }
+    if (empty($error)) {
+        
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <form action="" method="post">
+        <input type="text" name="event_name" placeholder="イベント名">
+        <input type="text" name='start_at'>
+        <input type="text" name="end_at">
+        <input type="text" name="detail">
+        <input type="submit" value="登録">
+    </form>
+</body>
+
+</html>

--- a/src/admin/add_event.php
+++ b/src/admin/add_event.php
@@ -1,18 +1,15 @@
 <?php
+
 require_once $_SERVER['DOCUMENT_ROOT'] . '/config.php';
 
 use cruds\Admin as Cruds;
 
-if ($_SERVER['HTTP_METHOD'] === 'POST') {
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $event_name = $_REQUEST['event_name'];
     $start_at = $_REQUEST['start_at'];
     $end_at = $_REQUEST['end_at'];
     $detail = $_REQUEST['detail'];
-    $error = array(
-        'event_name' => '',
-        'start_at' => '',
-        'end_at' => '',
-    );
+    $error = array();
     if (!isset($event_name)) {
         $error['event_name'] = 'blank';
     }
@@ -42,7 +39,7 @@ if ($_SERVER['HTTP_METHOD'] === 'POST') {
 </head>
 
 <body>
-    <form action="" method="post">
+    <form action="" method="POST">
         <?php if ($error['event_name'] === 'blank') : ?>
             <p>イベント名を入力してください</p>
         <?php endif ?>

--- a/src/admin/add_event.php
+++ b/src/admin/add_event.php
@@ -1,7 +1,9 @@
 <?php
+require_once $_SERVER['DOCUMENT_ROOT'] . '/config.php';
 
-if ($_SERVER['HTTP_METHOD'] === 'POST')
-{
+use cruds\Admin as Cruds;
+
+if ($_SERVER['HTTP_METHOD'] === 'POST') {
     $event_name = $_REQUEST['event_name'];
     $start_at = $_REQUEST['start_at'];
     $end_at = $_REQUEST['end_at'];
@@ -11,17 +13,21 @@ if ($_SERVER['HTTP_METHOD'] === 'POST')
         'start_at' => '',
         'end_at' => '',
     );
-    if (!isset($event_name)){
+    if (!isset($event_name)) {
         $error['event_name'] = 'blank';
     }
-    if (!isset($start_at)){
+    if (!isset($start_at)) {
         $error['start_at'] = 'blank';
     }
-    if (!isset($end_at)){
+    if (!isset($end_at)) {
         $error['end_at'] = 'blank';
     }
     if (empty($error)) {
-        
+        $cruds = new Cruds($db);
+        if ($cruds->create_event($event_name, $start_at, $end_at, $detail)) {
+            header('Location: http://' . $_SERVER['HTTP_HOST'] . '/admin/index.php');
+            exit();
+        }
     }
 }
 ?>
@@ -37,10 +43,27 @@ if ($_SERVER['HTTP_METHOD'] === 'POST')
 
 <body>
     <form action="" method="post">
-        <input type="text" name="event_name" placeholder="イベント名">
-        <input type="text" name='start_at'>
-        <input type="text" name="end_at">
-        <input type="text" name="detail">
+        <?php if ($error['event_name'] === 'blank') : ?>
+            <p>イベント名を入力してください</p>
+        <?php endif ?>
+        <label>
+            <input type="text" name="event_name" placeholder="イベント名">
+        </label>
+        <?php if ($error['start_at'] === 'blank') : ?>
+            <p>開始日時を入力してください</p>
+        <?php endif ?>
+        <label>
+            <input type="datetime-local" name='start_at'>
+        </label>
+        <?php if ($error['end_at'] === 'blank') : ?>
+            <p>終了日時を入力してください</p>
+        <?php endif ?>
+        <label>
+            <input type="datetime-local" name="end_at">
+        </label>
+        <label>
+            <input type="text" name="detail">
+        </label>
         <input type="submit" value="登録">
     </form>
 </body>

--- a/src/component/header.php
+++ b/src/component/header.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>Schedule | POSSE</title>
+</head>

--- a/src/cruds/Admin.php
+++ b/src/cruds/Admin.php
@@ -12,6 +12,15 @@ class Admin
         $this->db = $db;
     }
 
+    public function create_event($name, $start_at, $end_at)
+    {
+        $stmt = $this->db->prepare('INSERT INTO events (name, start_at, end_at) VALUES (:name, :start_at, :end_at)');
+        $stmt->bindValue(':name', $name, \PDO::PARAM_STR);
+        $stmt->bindValue(':start_at', $start_at, \PDO::PARAM_STR);
+        $stmt->bindValue(':end_at', $end_at, \PDO::PARAM_STR);
+        return $stmt->execute();
+    }
+
     public function get_user($email)
     {
         $stmt = $this->db->prepare('SELECT * FROM admins WHERE admins.email=:email');

--- a/src/cruds/Admin.php
+++ b/src/cruds/Admin.php
@@ -2,6 +2,7 @@
 
 
 namespace cruds;
+use modules\Utils;
 
 
 class Admin
@@ -15,6 +16,8 @@ class Admin
     public function create_event($name, $start_at, $end_at)
     {
         // TODO format input datetime to insert record
+        $start_at = Utils::convert_datetime($start_at);
+        $end_at = Utils::convert_datetime($end_at);
         $stmt = $this->db->prepare('INSERT INTO events (name, start_at, end_at) VALUES (:name, :start_at, :end_at)');
         $stmt->bindValue(':name', $name, \PDO::PARAM_STR);
         $stmt->bindValue(':start_at', $start_at, \PDO::PARAM_STR);

--- a/src/cruds/Admin.php
+++ b/src/cruds/Admin.php
@@ -14,6 +14,7 @@ class Admin
 
     public function create_event($name, $start_at, $end_at)
     {
+        // TODO format input datetime to insert record
         $stmt = $this->db->prepare('INSERT INTO events (name, start_at, end_at) VALUES (:name, :start_at, :end_at)');
         $stmt->bindValue(':name', $name, \PDO::PARAM_STR);
         $stmt->bindValue(':start_at', $start_at, \PDO::PARAM_STR);

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -3,8 +3,6 @@
 
 namespace cruds;
 
-use PDO;
-
 class User
 {
     protected $db;

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -16,7 +16,7 @@ class User
     public function read_events()
     {
 
-        $stmt = $this->db->query("SELECT events.id event_id, events.name, events.start_at, events.end_at,
+        $stmt = $this->db->query("SELECT events.id, events.name, events.start_at, events.end_at,
         count(event_attendance.id) AS total_participants FROM events
         LEFT JOIN event_attendance ON events.id = event_attendance.event_id
         where end_at > now() GROUP BY events.id
@@ -76,15 +76,15 @@ class User
     {
         $stmt = $this->db->prepare
         ("SELECT * FROM events WHERE id NOT IN(
-        SELECT event_id FROM event_attendance 
+        SELECT event_id FROM event_attendance
         WHERE user_id = :user_id)
         and end_at > now()
-        ");       
+        ");
         $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
         $stmt->execute();
         $unanswered_events = $stmt->fetchAll();
         return $unanswered_events;
-    }    
+    }
     public function update_user_password($email, $new_password)
     {
         $stmt = $this->db->prepare('UPDATE users SET hashed_password = :hashed_password

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -2,6 +2,7 @@
 
 
 namespace cruds;
+use PDO;
 
 class User
 {
@@ -23,7 +24,7 @@ class User
 
         if ($num > 0) {
             $events = array();
-            while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $row['attendance_users'] = $this->read_attendances($row['event_id']);
                 array_push($events, $row);
             }
@@ -33,7 +34,7 @@ class User
     public function get_user($email)
     {
         $stmt = $this->db->prepare('SELECT * FROM users WHERE users.email=:email');
-        $stmt->bindValue(':email', $email, \PDO::PARAM_STR);
+        $stmt->bindValue(':email', $email, PDO::PARAM_STR);
         $stmt->execute();
         return $stmt->fetch();
     }

--- a/src/cruds/domains/Email.php
+++ b/src/cruds/domains/Email.php
@@ -6,5 +6,4 @@ namespace cruds\domains;
 
 class Email
 {
-    
 }

--- a/src/index.php
+++ b/src/index.php
@@ -1,6 +1,6 @@
 <?php
 require_once('config.php');
-use cruds\User;
+use cruds\User as Cruds;
 use modules\auth\User as Auth;
 
 $auth = new Auth($db);
@@ -8,7 +8,7 @@ $auth = new Auth($db);
 $auth->validate();
 $user_id = $_SESSION['user']['id'];
 
-$crud = new User($db);
+$crud = new Cruds($db);
 
 $events=$crud->read_events();
 

--- a/src/index.php
+++ b/src/index.php
@@ -26,18 +26,12 @@ function get_day_of_week($w)
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
+include dirname(__FILE__) . '/component/header.php';
 ?>
 
 <!DOCTYPE html>
 <html lang="ja">
-
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
-  <title>Schedule | POSSE</title>
-</head>
 
 <body>
   <header class="h-16">

--- a/src/modules/Utils.php
+++ b/src/modules/Utils.php
@@ -14,4 +14,9 @@ class Utils
     {
         return json_encode($var, JSON_UNESCAPED_UNICODE);
     }
+    public static function convert_datetime($datetime_local)
+    {
+        return date('Y-m-d H:i:s', strtotime($datetime_local));
+    }
+
 }


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/27

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
・イベントをフォームから送信して作成すると、DBに反映されることを確認しました。

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="1248" alt="2022-09-08 (16)" src="https://user-images.githubusercontent.com/86541032/189130186-1437fed3-66f7-439e-8dff-b0977b9f196d.png">


<img width="1032" alt="スクリーンショット 2022-09-07 17 35 59" src="https://user-images.githubusercontent.com/72688676/188831882-72c32cb7-2529-4438-af5b-9ccaf200d53f.png">
