### PR TITLE
#29 画面からイベント情報を変更できるようにする

### DIFF
--- a/src/admin/event.php
+++ b/src/admin/event.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/config.php';
+
+use cruds\Admin as Cruds;
+use modules\auth\Admin as Auth;
+use modules\Utils;
+
+$auth = new Auth($db);
+
+$auth->validate();
+
+$crud = new Cruds($db);
+
+$events = $crud->get_events();
+
+$event_id = $_GET['id'];
+
+if (!isset($event_id)) {
+    header('Location: http://' . $_SERVER['HTTP_HOST'] . '/admin/index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $name = $_REQUEST['name'];
+    $start_at = $_REQUEST['start_at'];
+    $end_at = $_REQUEST['end_at'];
+    $detail = $_REQUEST['detail'];
+
+    $error = array();
+
+    if (!isset($name)) {
+        $error['name'] = 'blank';
+    }
+    if (!isset($start_at)) {
+        $error['start_at'] = 'blank';
+    }
+    if (!isset($end_at)) {
+        $error['end_at'] = 'blank';
+    }
+    if (!isset($detail)) {
+        $error['detail'] = 'blank';
+    }
+
+    if (empty($error)) {
+        $update = $crud->update_event($event_id, $name, $start_at, $end_at, $detail);
+        if ($update) {
+            header("Location: http://" . $_SERVER['HTTP_HOST'] .'/admin');
+            exit();
+        }
+    }
+}
+
+$event = $crud->get_event($event_id);
+
+?>
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+    <title>Schedule | POSSE</title>
+</head>
+
+<body>
+    <header class="h-16">
+        <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+            <div class="h-full">
+                <img src="/img/header-logo.png" alt="" class="h-full">
+            </div>
+        </div>
+    </header>
+
+
+    <main class="bg-gray-100">
+        <div class="w-full mx-auto p-5">
+            <div id="filter" class="mb-8">
+                <h2 class="text-sm font-bold mb-3">フィルター</h2>
+                <div id="attendance_button_container" class="flex">
+                    <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
+                    <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+                    <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+                    <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+                </div>
+            </div>
+
+
+
+
+            <div id="events-list">
+                <div class="flex justify-between items-center mb-3">
+                    <h2 class="text-sm font-bold">一覧</h2>
+                </div>
+                <?php
+                $start_date = strtotime($event['start_at']);
+                $end_date = strtotime($event['end_at']);
+                $day_of_week = Utils::get_day_of_week(date("w", $start_date));
+                ?>
+                <form class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>" action="" method="POST">
+                    <div>
+                        <input class="font-bold text-lg mb-2" value="<?= $event['name'] ?>" placeholder="イベント名" name="name">
+                        <br>
+                        <label>開始時刻：<input type="datetime-local" name="start_at" value="<?= $event['start_at'] ?>"></label>
+                        <br>
+                        <label>終了時刻：<input type="datetime-local" name="end_at" value="<?= $event['end_at'] ?>"></label>
+                        <textarea name="detail" id="" cols="30" rows="10" class="w-full p-4 text-sm mb-3" placeholder="イベント内容"></textarea>
+                        <input type="submit" value="変更" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+                    </div>
+                </form>
+            </div>
+        </div>
+</body>
+
+</html>

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -3,12 +3,15 @@
 require_once $_SERVER['DOCUMENT_ROOT'] . '/config.php';
 use cruds\Admin as Cruds;
 use modules\auth\Admin as Auth;
+use modules\Utils;
 
 $auth = new Auth($db);
 
 $auth->validate();
 
 $crud = new Cruds($db);
+
+$events = $crud->get_events();
 
   ?>
 
@@ -32,7 +35,63 @@ $crud = new Cruds($db);
       </div>
     </header>
 
-    home
+
+  <main class="bg-gray-100">
+    <div class="w-full mx-auto p-5">
+      <div id="filter" class="mb-8">
+        <h2 class="text-sm font-bold mb-3">フィルター</h2>
+        <div id="attendance_button_container" class="flex">
+          <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
+          <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+          <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+          <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+        </div>
+      </div>
+
+
+
+
+      <div id="events-list">
+        <div class="flex justify-between items-center mb-3">
+          <h2 class="text-sm font-bold">一覧</h2>
+        </div>
+
+        <?php foreach ($events as $event) : ?>
+          <?php
+          $start_date = strtotime($event['start_at']);
+          $end_date = strtotime($event['end_at']);
+          $day_of_week = Utils::get_day_of_week(date("w", $start_date));
+          ?>
+          <a class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>" href="event.php?id=<?= $event['id'] ?>">
+            <div>
+              <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+              <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+              <p class="text-xs text-gray-600">
+                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+              </p>
+            </div>
+            <div class="flex flex-col justify-between text-right">
+              <div>
+                <?php if ($event['id'] % 3 === 1) : ?>
+                  <!--
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  -->
+                <?php elseif ($event['id'] % 3 === 2) : ?>
+                  <!--
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                  -->
+                <?php else : ?>
+                  <!--
+                  <p class="text-sm font-bold text-green-400">参加</p>
+                  -->
+                <?php endif; ?>
+              </div>
+            </div>
+          </a>
+        <?php endforeach; ?>
+      </div>
+    </div>
   </body>
 
   </html>

--- a/src/cruds/Admin.php
+++ b/src/cruds/Admin.php
@@ -45,4 +45,38 @@ class Admin
         $stmt->bindValue(':username', $username, \PDO::PARAM_STR);
         return $stmt->execute();
     }
+
+    public function get_events()
+    {
+        $stmt = $this->db->query("SELECT * FROM events");
+        $stmt->execute();
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function get_event($event_id)
+    {
+        $stmt = $this->db->prepare("SELECT * FROM events
+        WHERE id = :id");
+        $stmt->bindValue(':id', $event_id, \PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch();
+    }
+
+    public function update_event($event_id, $name, $start_at, $end_at, $detail)
+    {
+        $start_at = Utils::convert_datetime($start_at);
+        $end_at = Utils::convert_datetime($end_at);
+        $stmt = $this->db->prepare("UPDATE events
+        SET name = :name,
+        start_at = :start_at,
+        end_at = :end_at,
+        detail = :detail
+        WHERE id = :id");
+        $stmt->bindValue(':name', $name, \PDO::PARAM_STR);
+        $stmt->bindValue(':start_at', $start_at, \PDO::PARAM_STR);
+        $stmt->bindValue(':end_at', $end_at, \PDO::PARAM_STR);
+        $stmt->bindValue(':detail', $detail, \PDO::PARAM_STR);
+        $stmt->bindValue(':id', $event_id, \PDO::PARAM_STR);
+        return $stmt->execute();
+    }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -2,6 +2,7 @@
 require_once('config.php');
 use cruds\User as Cruds;
 use modules\auth\User as Auth;
+use modules\Utils;
 
 $auth = new Auth($db);
 
@@ -21,11 +22,7 @@ if (isset($_GET['is_answered'])) {
   $events = $crud->read_unanswered_events($user_id, $is_attendance);
 }
 
-function get_day_of_week($w)
-{
-  $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
-  return $day_of_week_list["$w"];
-}
+
 
 include dirname(__FILE__) . '/component/header.php';
 ?>
@@ -66,7 +63,7 @@ include dirname(__FILE__) . '/component/header.php';
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
-          $day_of_week = get_day_of_week(date("w", $start_date));
+          $day_of_week = Utils::get_day_of_week(date("w", $start_date));
           ?>
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
@@ -104,7 +101,7 @@ include dirname(__FILE__) . '/component/header.php';
     </div>
 
 
-    
+
   <!-- ページネーション -->
   <!-- This example requires Tailwind CSS v2.0+ -->
   <div class="flex items-center justify-items-center px-4 py-3 sm:px-6">

--- a/src/modules/Utils.php
+++ b/src/modules/Utils.php
@@ -18,5 +18,9 @@ class Utils
     {
         return date('Y-m-d H:i:s', strtotime($datetime_local));
     }
-
+    public static function get_day_of_week($w)
+    {
+      $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
+      return $day_of_week_list["$w"];
+    }
 }


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/29

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
管理画面で一覧が表示されること、イベントをクリックすると編集ページに飛ぶこと、編集するとDBに反映されることを確認しました。



## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="1710" alt="スクリーンショット 2022-09-07 22 13 19" src="https://user-images.githubusercontent.com/72688676/188887510-65ef0b87-1e43-48c5-b44d-888afad87365.png">
<img width="1710" alt="スクリーンショット 2022-09-07 22 13 31" src="https://user-images.githubusercontent.com/72688676/188887581-0ffed1be-23a1-42cc-8c5e-27040ae87a8d.png">


