### PR TITLE
#19 ユーザーの参加／不参加の情報をDBに保存する

### DIFF
--- a/src/attendance.php
+++ b/src/attendance.php
@@ -1,0 +1,145 @@
+<?php
+require_once('config.php');
+
+use cruds\User as Cruds;
+use modules\auth\User as Auth;
+use modules\Utils;
+
+$auth = new Auth($db);
+
+$auth->validate();
+$user_id = $_SESSION['user']['id'];
+
+$crud = new Cruds($db);
+
+$event_id = $_GET['event_id'];
+if (!isset($event_id)) {
+    header('Location: http://' . $_SERVER['HTTP_HOST'] . '/');
+    exit();
+}
+
+$event = $crud->read_event($event_id);
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if (isset($_REQUEST['is_attendance'])) {
+        $event_id = $_REQUEST['event_id'];
+        $is_attendance = $_REQUEST['is_attendance'];
+
+        $success = $crud->handle_attendance($event_id, $user_id, $is_attendance);
+        if ($success) {
+            header("Location: http://" . $_SERVER['HTTP_HOST'] . '/?is_attendance=' . $is_attendance);
+            exit();
+        }
+    }
+}
+
+include dirname(__FILE__) . '/component/header.php';
+?>
+<header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+        <div class="h-full">
+            <img src="img/header-logo.png" alt="" class="h-full">
+        </div>
+
+        <div>
+            <a href="/auth/password_reset" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">password reset</a>
+        </div>
+
+    </div>
+</header>
+
+<main class="bg-gray-100">
+    <div class="w-full mx-auto p-5">
+        <div id="filter" class="mb-8">
+            <h2 class="text-sm font-bold mb-3">フィルター</h2>
+            <div id="attendance_button_container" class="flex">
+                <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
+                <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+                <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+                <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+            </div>
+        </div>
+
+
+
+
+        <div id="events-list">
+            <div class="flex justify-between items-center mb-3">
+                <h2 class="text-sm font-bold">一覧</h2>
+            </div>
+            <?php
+            $start_date = strtotime($event['start_at']);
+            $end_date = strtotime($event['end_at']);
+            $day_of_week = Utils::get_day_of_week(date("w", $start_date));
+            ?>
+            <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+                <div>
+                    <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                    <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                    <p class="text-xs text-gray-600">
+                        <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                    </p>
+                </div>
+                <div class="flex flex-col justify-between text-right">
+                    <div>
+                        <?php if ($event['id'] % 3 === 1) : ?>
+                            <!--
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  -->
+                        <?php elseif ($event['id'] % 3 === 2) : ?>
+                            <!--
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                  -->
+                        <?php else : ?>
+                            <!--
+                  <p class="text-sm font-bold text-green-400">参加</p>
+                  -->
+                        <?php endif; ?>
+                    </div>
+                    <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+                    <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+                        <div><?= $attendance['username'] ?></div>
+                    <?php endforeach ?>
+                </div>
+            </div>
+
+            <div>
+                <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                <p class="text-xs text-gray-600">
+                    <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                </p>
+            </div>
+            <div class="flex flex-col justify-between text-right">
+                <div>
+                    <?php if ($event['id'] % 3 === 1) : ?>
+                        <!--
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  -->
+                    <?php elseif ($event['id'] % 3 === 2) : ?>
+                        <!--
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                  -->
+                    <?php else : ?>
+                        <!--
+                  <p class="text-sm font-bold text-green-400">参加</p>
+                  -->
+                    <?php endif; ?>
+                </div>
+                <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+                <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+                    <div><?= $attendance['username'] ?></div>
+                <?php endforeach ?>
+            </div>
+            <form action="" method="POST">
+                <input type="hidden" name="event_id" value="<?= $event['id'] ?>">
+                <label for="attendance_radio"><input id="attendance_radio" type="radio" value="1" name="is_attendance">参加</label>
+                <label for="unattendance_radio"><input id="unattendance_radio" type="radio" value="0" name="is_attendance">不参加</label>
+                <br>
+                <input type="submit" value="登録" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
+            </form>
+        </div>
+    </div>
+</main>

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -63,13 +63,22 @@ class User
         INNER JOIN users ON users.id = event_attendance.user_id
         where end_at > now()
         and users.id = :user_id
-        and is_attendance = :is_attendance
+        and event_attendance.is_attendance = :is_attendance
         ");
         $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
         $stmt->bindValue(':is_attendance', $is_attendance, PDO::PARAM_BOOL);
         $stmt->execute();
-        $attendant_events = $stmt->fetchAll();
-        return $attendant_events;
+        $num = $stmt->rowCount();
+
+        if ($num > 0) {
+            $events = array();
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                $row['attendance_users'] = $this->read_attendances($row['event_id']);
+                array_push($events, $row);
+            }
+            return $events;
+        }
+        return array(); 
     }
     public function read_unanswered_events($user_id)
     {

--- a/src/index.php
+++ b/src/index.php
@@ -23,7 +23,18 @@ if (isset($_GET['is_answered'])) {
   $events = $crud->read_unanswered_events($user_id, $is_attendance);
 }
 
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+  if (isset($_REQUEST['is_attendance'])) {
+    $event_id = $_REQUEST['event_id'];
+    $is_attendance = $_REQUEST['is_attendance'];
 
+    $success = $crud->handle_attendance($event_id, $user_id, $is_attendance);
+    if ($success) {
+      header("Location: http://" . $_SERVER['HTTP_HOST'] . '/?is_attendance=' . $is_attendance);
+      exit();
+    }
+  }
+}
 
 include dirname(__FILE__) . '/component/header.php';
 ?>
@@ -109,35 +120,42 @@ include dirname(__FILE__) . '/component/header.php';
               </div>
 
               <div id="modalInner">
-              <div>
-            <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-            <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-            <p class="text-xs text-gray-600">
-              <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-            </p>
-          </div>
-          <div class="flex flex-col justify-between text-right">
-            <div>
-              <?php if ($event['id'] % 3 === 1) : ?>
-                <!--
+                <div>
+                  <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                  <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                  <p class="text-xs text-gray-600">
+                    <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                  </p>
+                </div>
+                <div class="flex flex-col justify-between text-right">
+                  <div>
+                    <?php if ($event['id'] % 3 === 1) : ?>
+                      <!--
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
                   <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
                   -->
-              <?php elseif ($event['id'] % 3 === 2) : ?>
-                <!--
+                    <?php elseif ($event['id'] % 3 === 2) : ?>
+                      <!--
                   <p class="text-sm font-bold text-gray-300">不参加</p>
                   -->
-              <?php else : ?>
-                <!--
+                    <?php else : ?>
+                      <!--
                   <p class="text-sm font-bold text-green-400">参加</p>
                   -->
-              <?php endif; ?>
-            </div>
-            <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
-            <?php foreach ($event['attendance_users'] as $attendance) :  ?>
-              <div><?= $attendance['username'] ?></div>
-            <?php endforeach ?>
-          </div>
+                    <?php endif; ?>
+                  </div>
+                  <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+                  <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+                    <div><?= $attendance['username'] ?></div>
+                  <?php endforeach ?>
+                </div>
+                <form action="" method="POST">
+                  <input type="hidden" name="event_id" value="<?= $event['id'] ?>">
+                  <label for="attendance_radio"><input id="attendance_radio" type="radio" value="1" name="is_attendance">参加</label>
+                  <label for="unattendance_radio"><input id="unattendance_radio" type="radio" value="0" name="is_attendance">不参加</label>
+                  <br>
+                  <input type="submit" value="登録" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
+                </form>
               </div>
 
             </div>

--- a/src/index.php
+++ b/src/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+
 use cruds\User as Cruds;
 use modules\auth\User as Auth;
 use modules\Utils;
@@ -26,79 +27,125 @@ if (isset($_GET['is_answered'])) {
 
 include dirname(__FILE__) . '/component/header.php';
 ?>
-  <header class="h-16">
-    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
-      <div class="h-full">
-        <img src="img/header-logo.png" alt="" class="h-full">
-      </div>
-
-      <div>
-        <a href="/auth/password_reset" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">password reset</a>
-      </div>
-
+<header class="h-16">
+  <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+    <div class="h-full">
+      <img src="img/header-logo.png" alt="" class="h-full">
     </div>
-  </header>
 
-  <main class="bg-gray-100">
-    <div class="w-full mx-auto p-5">
-      <div id="filter" class="mb-8">
-        <h2 class="text-sm font-bold mb-3">フィルター</h2>
-        <div id="attendance_button_container" class="flex">
-          <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
-          <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
-        </div>
+    <div>
+      <a href="/auth/password_reset" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">password reset</a>
+    </div>
+
+  </div>
+</header>
+
+<main class="bg-gray-100">
+  <div class="w-full mx-auto p-5">
+    <div id="filter" class="mb-8">
+      <h2 class="text-sm font-bold mb-3">フィルター</h2>
+      <div id="attendance_button_container" class="flex">
+        <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
+        <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+        <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+        <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+      </div>
+    </div>
+
+
+
+
+    <div id="events-list">
+      <div class="flex justify-between items-center mb-3">
+        <h2 class="text-sm font-bold">一覧</h2>
       </div>
 
-
-
-
-      <div id="events-list">
-        <div class="flex justify-between items-center mb-3">
-          <h2 class="text-sm font-bold">一覧</h2>
-        </div>
-
-        <?php foreach ($events as $event) : ?>
-          <?php
-          $start_date = strtotime($event['start_at']);
-          $end_date = strtotime($event['end_at']);
-          $day_of_week = Utils::get_day_of_week(date("w", $start_date));
-          ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+      <?php foreach ($events as $event) : ?>
+        <?php
+        $start_date = strtotime($event['start_at']);
+        $end_date = strtotime($event['end_at']);
+        $day_of_week = Utils::get_day_of_week(date("w", $start_date));
+        ?>
+        <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+          <div>
+            <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+            <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+            <p class="text-xs text-gray-600">
+              <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+            </p>
+          </div>
+          <div class="flex flex-col justify-between text-right">
             <div>
-              <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-              <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-              <p class="text-xs text-gray-600">
-                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-              </p>
-            </div>
-            <div class="flex flex-col justify-between text-right">
-              <div>
-                <?php if ($event['id'] % 3 === 1) : ?>
-                  <!--
+              <?php if ($event['id'] % 3 === 1) : ?>
+                <!--
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
                   <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
                   -->
-                <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <!--
+              <?php elseif ($event['id'] % 3 === 2) : ?>
+                <!--
                   <p class="text-sm font-bold text-gray-300">不参加</p>
                   -->
-                <?php else : ?>
-                  <!--
+              <?php else : ?>
+                <!--
                   <p class="text-sm font-bold text-green-400">参加</p>
                   -->
-                <?php endif; ?>
+              <?php endif; ?>
+            </div>
+            <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+            <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+              <div><?= $attendance['username'] ?></div>
+            <?php endforeach ?>
+          </div>
+        </div>
+        <div class="modal opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
+          <div class="modal-overlay absolute w-full h-full bg-black opacity-80"></div>
+
+          <div class="modal-container absolute bottom-0 bg-white w-screen h-4/5 rounded-t-3xl shadow-lg z-50">
+            <div class="modal-content text-left py-6 pl-10 pr-6">
+              <div class="z-50 text-right mb-5">
+                <svg class="modal-close cursor-pointer inline bg-gray-100 p-1 rounded-full" xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 18 18">
+                  <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"></path>
+                </svg>
               </div>
-              <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
-              <?php foreach ($event['attendance_users'] as $attendance) :  ?>
-                <div><?= $attendance['username'] ?></div>
-              <?php endforeach ?>
+
+              <div id="modalInner">
+              <div>
+            <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+            <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+            <p class="text-xs text-gray-600">
+              <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+            </p>
+          </div>
+          <div class="flex flex-col justify-between text-right">
+            <div>
+              <?php if ($event['id'] % 3 === 1) : ?>
+                <!--
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  -->
+              <?php elseif ($event['id'] % 3 === 2) : ?>
+                <!--
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                  -->
+              <?php else : ?>
+                <!--
+                  <p class="text-sm font-bold text-green-400">参加</p>
+                  -->
+              <?php endif; ?>
+            </div>
+            <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+            <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+              <div><?= $attendance['username'] ?></div>
+            <?php endforeach ?>
+          </div>
+              </div>
+
             </div>
           </div>
-        <?php endforeach; ?>
-      </div>
+        </div>
+      <?php endforeach; ?>
     </div>
+  </div>
 
 
 
@@ -138,55 +185,40 @@ include dirname(__FILE__) . '/component/header.php';
       </div>
     </div>
   </div>
-  </main>
+</main>
 
 
 
-  <div class="modal opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
-    <div class="modal-overlay absolute w-full h-full bg-black opacity-80"></div>
-
-    <div class="modal-container absolute bottom-0 bg-white w-screen h-4/5 rounded-t-3xl shadow-lg z-50">
-      <div class="modal-content text-left py-6 pl-10 pr-6">
-        <div class="z-50 text-right mb-5">
-          <svg class="modal-close cursor-pointer inline bg-gray-100 p-1 rounded-full" xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 18 18">
-            <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"></path>
-          </svg>
-        </div>
-
-        <div id="modalInner"></div>
-
-      </div>
-    </div>
-  </div>
 
 
-  <script src="/js/main.js"></script>
+
+<script src="/js/main.js"></script>
+<script>
+  const attendance_buttons = document.querySelectorAll('#attendance_button_container>a');
+
+  function changedButtonColor(attendance_id) {
+    attendance_buttons[attendance_id].classList.add('bg-blue-600');
+    attendance_buttons[attendance_id].classList.add('text-white');
+
+  }
+</script>
+<?php if ($is_answered == '1') { ?>
   <script>
-    const attendance_buttons = document.querySelectorAll('#attendance_button_container>a');
-
-    function changedButtonColor(attendance_id) {
-      attendance_buttons[attendance_id].classList.add('bg-blue-600');
-      attendance_buttons[attendance_id].classList.add('text-white');
-
-    }
+    changedButtonColor(3);
   </script>
-  <?php if ($is_answered == '1') { ?>
-    <script>
-      changedButtonColor(3);
-    </script>
-  <?php } else if ($is_attendance == '1') { ?>
-    <script>
-      changedButtonColor(1);
-    </script>
-  <?php } else if ($is_attendance == '0') { ?>
-    <script>
-      changedButtonColor(2);
-    </script>
-  <?php } else { ?>
-    <script>
-      changedButtonColor(0);
-    </script>
-  <?php } ?>
+<?php } else if ($is_attendance == '1') { ?>
+  <script>
+    changedButtonColor(1);
+  </script>
+<?php } else if ($is_attendance == '0') { ?>
+  <script>
+    changedButtonColor(2);
+  </script>
+<?php } else { ?>
+  <script>
+    changedButtonColor(0);
+  </script>
+<?php } ?>
 
 
 </body>

--- a/src/index.php
+++ b/src/index.php
@@ -23,19 +23,6 @@ if (isset($_GET['is_answered'])) {
   $events = $crud->read_unanswered_events($user_id, $is_attendance);
 }
 
-if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-  if (isset($_REQUEST['is_attendance'])) {
-    $event_id = $_REQUEST['event_id'];
-    $is_attendance = $_REQUEST['is_attendance'];
-
-    $success = $crud->handle_attendance($event_id, $user_id, $is_attendance);
-    if ($success) {
-      header("Location: http://" . $_SERVER['HTTP_HOST'] . '/?is_attendance=' . $is_attendance);
-      exit();
-    }
-  }
-}
-
 include dirname(__FILE__) . '/component/header.php';
 ?>
 <header class="h-16">
@@ -77,7 +64,7 @@ include dirname(__FILE__) . '/component/header.php';
         $end_date = strtotime($event['end_at']);
         $day_of_week = Utils::get_day_of_week(date("w", $start_date));
         ?>
-        <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+        <a class="bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>" href="/attendance.php?event_id=<?= $event['id'] ?>">
           <div>
             <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
             <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -107,7 +94,7 @@ include dirname(__FILE__) . '/component/header.php';
               <div><?= $attendance['username'] ?></div>
             <?php endforeach ?>
           </div>
-        </div>
+        </a>
         <div class="modal opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
           <div class="modal-overlay absolute w-full h-full bg-black opacity-80"></div>
 
@@ -204,10 +191,6 @@ include dirname(__FILE__) . '/component/header.php';
     </div>
   </div>
 </main>
-
-
-
-
 
 
 <script src="/js/main.js"></script>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/19

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
topページで参加 不参加の登録ができることを確認しました。


## エビデンス
<img width="1710" alt="スクリーンショット 2022-09-08 23 00 02" src="https://user-images.githubusercontent.com/72688676/189142743-9f0c3ff5-82e1-499f-a987-cb22d8fb78e5.png">
<img width="1710" alt="スクリーンショット 2022-09-08 23 00 05" src="https://user-images.githubusercontent.com/72688676/189142801-093c6ff6-6cb8-4d0b-9f30-c9bc549194d4.png">
<img width="1710" alt="スクリーンショット 2022-09-08 23 02 52" src="https://user-images.githubusercontent.com/72688676/189142861-d26edb46-cdf9-4eac-87d5-d2ab47c277c0.png">

<!-- こちらに画面キャプチャを貼ってください -->
