### PR TITLE
#20  参加状態により参加／不参加ボタンを活性／非活性にする

### DIFF
--- a/src/attendance.php
+++ b/src/attendance.php
@@ -18,7 +18,7 @@ if (!isset($event_id)) {
     exit();
 }
 
-$event = $crud->read_event($event_id);
+$event = $crud->read_event($event_id, $user_id);
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     if (isset($_REQUEST['is_attendance'])) {
@@ -49,61 +49,16 @@ include dirname(__FILE__) . '/component/header.php';
 </header>
 
 <main class="bg-gray-100">
-    <div class="w-full mx-auto p-5">
-        <div id="filter" class="mb-8">
-            <h2 class="text-sm font-bold mb-3">フィルター</h2>
-            <div id="attendance_button_container" class="flex">
-                <a href="index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">全て</a>
-                <a href="index.php?is_attendance=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-                <a href="index.php?is_attendance=0" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-                <a href="index.php?is_answered=1" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
-            </div>
+    <div id="events-list">
+        <div class="flex justify-between items-center mb-3">
+            <h2 class="text-sm font-bold">一覧</h2>
         </div>
-
-
-
-
-        <div id="events-list">
-            <div class="flex justify-between items-center mb-3">
-                <h2 class="text-sm font-bold">一覧</h2>
-            </div>
-            <?php
-            $start_date = strtotime($event['start_at']);
-            $end_date = strtotime($event['end_at']);
-            $day_of_week = Utils::get_day_of_week(date("w", $start_date));
-            ?>
-            <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
-                <div>
-                    <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-                    <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-                    <p class="text-xs text-gray-600">
-                        <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-                    </p>
-                </div>
-                <div class="flex flex-col justify-between text-right">
-                    <div>
-                        <?php if ($event['id'] % 3 === 1) : ?>
-                            <!--
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
-                  -->
-                        <?php elseif ($event['id'] % 3 === 2) : ?>
-                            <!--
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                  -->
-                        <?php else : ?>
-                            <!--
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                  -->
-                        <?php endif; ?>
-                    </div>
-                    <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
-                    <?php foreach ($event['attendance_users'] as $attendance) :  ?>
-                        <div><?= $attendance['username'] ?></div>
-                    <?php endforeach ?>
-                </div>
-            </div>
-
+        <?php
+        $start_date = strtotime($event['start_at']);
+        $end_date = strtotime($event['end_at']);
+        $day_of_week = Utils::get_day_of_week(date("w", $start_date));
+        ?>
+        <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
                 <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
                 <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -133,13 +88,48 @@ include dirname(__FILE__) . '/component/header.php';
                     <div><?= $attendance['username'] ?></div>
                 <?php endforeach ?>
             </div>
-            <form action="" method="POST">
-                <input type="hidden" name="event_id" value="<?= $event['id'] ?>">
-                <label for="attendance_radio"><input id="attendance_radio" type="radio" value="1" name="is_attendance">参加</label>
-                <label for="unattendance_radio"><input id="unattendance_radio" type="radio" value="0" name="is_attendance">不参加</label>
-                <br>
-                <input type="submit" value="登録" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
-            </form>
         </div>
+
+        <div>
+            <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+            <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+            <p class="text-xs text-gray-600">
+                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+            </p>
+        </div>
+        <div class="flex flex-col justify-between text-right">
+            <div>
+                <?php if ($event['id'] % 3 === 1) : ?>
+                    <!--
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  -->
+                <?php elseif ($event['id'] % 3 === 2) : ?>
+                    <!--
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                  -->
+                <?php else : ?>
+                    <!--
+                  <p class="text-sm font-bold text-green-400">参加</p>
+                  -->
+                <?php endif; ?>
+            </div>
+            <p class="text-sm"><span class="text-xl"><?= count($event['attendance_users']) ?></span>人参加 ></p>
+            <?php foreach ($event['attendance_users'] as $attendance) :  ?>
+                <div><?= $attendance['username'] ?></div>
+            <?php endforeach ?>
+        </div>
+        <form action="" method="POST">
+            <input type="hidden" name="event_id" value="<?= $event['id'] ?>">
+            <label for="attendance_radio"><input id="attendance_radio" type="radio" value="1" name="is_attendance" <?php if ($event['is_attendance']) {
+                echo 'disabled';
+            } ?>>参加</label>
+            <label for="unattendance_radio"><input id="unattendance_radio" type="radio" value="0" name="is_attendance" <?php if (!$event['is_attendance']) {
+                echo 'disabled';
+            } ?>>不参加</label>
+            <br>
+            <input type="submit" value="登録" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
+        </form>
+    </div>
     </div>
 </main>

--- a/src/cruds/User.php
+++ b/src/cruds/User.php
@@ -33,14 +33,17 @@ class User
         }
     }
 
-    public function read_event($event_id)
+    public function read_event($event_id, $user_id)
     {
-        $stmt = $this->db->prepare("SELECT events.id, events.name, events.start_at, events.end_at,
-        count(event_attendance.id) AS total_participants FROM events
-        LEFT JOIN event_attendance ON events.id = event_attendance.event_id
-        where events.id = :event_id
-        ORDER BY start_at");
+        $stmt = $this->db->prepare("SELECT events.id id, events.name name, events.start_at start_at, events.end_at end_at,
+        event_attendance.is_attendance is_attendance,
+        count(event_attendance.id) total_participants FROM events
+        INNER JOIN event_attendance ON events.id = event_attendance.event_id
+        where event_attendance.event_id = :event_id AND
+        event_attendance.user_id = :user_id
+        GROUP BY event_attendance.is_attendance");
         $stmt->bindValue(':event_id', $event_id, PDO::PARAM_INT);
+        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
         $stmt->execute();
         $row = $stmt->fetch();
         $row['attendance_users'] = $this->read_attendances($row['event_id']);


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/20

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
ボタンが参加/不参加で押せなくなるようになることを確認しました。

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="1710" alt="スクリーンショット 2022-09-08 10 35 51" src="https://user-images.githubusercontent.com/72688676/189014158-24e5cc48-73da-4514-a206-957e0ca65287.png">
<img width="1710" alt="スクリーンショット 2022-09-08 10 35 59" src="https://user-images.githubusercontent.com/72688676/189014176-4426c4e9-43cd-4119-b3ae-deed718a8b07.png">
<img width="1710" alt="スクリーンショット 2022-09-08 10 36 08" src="https://user-images.githubusercontent.com/72688676/189014201-8b9278be-b0ca-42e5-a7fc-f8cdc1f3472a.png">

<img width="1710" alt="スクリーンショット 2022-09-08 10 36 17" src="https://user-images.githubusercontent.com/72688676/189014217-a13ec9e6-6da9-48b9-843c-ba764321f110.png">

