### PR TITLE
#25 イベントの前日に参加としている人のみにメール通知

### DIFF
--- a/demo.sql
+++ b/demo.sql
@@ -1,5 +1,5 @@
 --SQLで未回答者一覧を出力する #30
-SELECT event_id,events.name,username,start_at FROM users 
+SELECT event_id,events.name,username,start_at FROM users
 INNER JOIN event_attendance ON users.id = user_id
 INNER JOIN events ON events.id = event_id
 WHERE start_at > now()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
   app:
     build: ./php
     container_name: hackathon_phpfpm_dev
+    platform: linux/arm64
     depends_on:
       - db
     volumes:
@@ -27,8 +28,9 @@ services:
     env_file:
       - .env.development
   db:
-    image: mysql:latest
+    image: mysql:8.0
     container_name: hackathon_mysql_dev
+    platform: linux/amd64
     environment:
       TZ: "Asia/Tokyo"
     env_file:
@@ -42,5 +44,6 @@ services:
   mailhog:
     container_name: hackathon_mail_dev
     image: mailhog/mailhog
+    platform: linux/amd64
     ports:
       - "8025:8025"

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,10 +1,14 @@
+FROM golang:1.15 AS builder
+RUN go get -d -v github.com/mailhog/mhsendmail \
+  && cd /go/src/github.com/mailhog/mhsendmail/ \
+  && GOOS=linux GOARCH=arm64 go build -o mhsendmail .
+
 FROM php:7.4.7-fpm
 WORKDIR /var/www/html
-RUN apt-get update \
+COPY --from=builder /go/src/github.com/mailhog/mhsendmail/mhsendmail /usr/local/bin/
+RUN chmod +x /usr/local/bin/mhsendmail \
+&& apt-get update \
   && docker-php-ext-install pdo_mysql
-RUN curl -sSL https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 -o mhsendmail \
-  && chmod +x mhsendmail \
-  && mv mhsendmail /usr/local/bin/mhsendmail
 RUN pecl install xdebug && \
     docker-php-ext-enable xdebug
 COPY ./php.ini /usr/local/etc/php/

--- a/src/cruds/Notification.php
+++ b/src/cruds/Notification.php
@@ -23,10 +23,9 @@ class Notification
     $stmt -> execute();
     return $stmt -> fetchAll();
   }
-<<<<<<< HEAD
 
   public function get_attendee() {
-    $stmt = $this->db ->prepare("SELECT name,email FROM users JOIN event_attendance on users.id = event_attendance.user_id 
+    $stmt = $this->db ->prepare("SELECT name,email FROM users JOIN event_attendance on users.id = event_attendance.user_id
     JOIN events ON event_attendance.event_id = events.id WHERE is_attendance = true and DATE(start_at) = DATE_ADD(CURRENT_DATE, INTERVAL 1 DAY)");
     $stmt -> execute();
     return $stmt -> fetchAll();
@@ -34,8 +33,8 @@ class Notification
 
   //必要？
   public function tomorrow_event() {
-    $stmt = $this->db ->prepare("SELECT event_id,count(*) FROM users JOIN event_attendance on users.id = event_attendance.user_id 
-    JOIN events ON event_attendance.event_id = events.id 
+    $stmt = $this->db ->prepare("SELECT event_id,count(*) FROM users JOIN event_attendance on users.id = event_attendance.user_id
+    JOIN events ON event_attendance.event_id = events.id
     WHERE is_attendance = true and DATE(start_at) = DATE_ADD(CURRENT_DATE, INTERVAL 1 DAY)
     group by event_id");
     $stmt -> execute();
@@ -47,6 +46,17 @@ class Notification
     $stmt -> execute();
     return $stmt -> fetchAll();
   }
-=======
->>>>>>> 56e15cba46cf8d3a839bf43306067d681cefb233
+
+  public function get_users_and_event_info_before_day()
+  {
+    $stmt = $this->db->query("SELECT users.email email, events.name event_name,
+    events.detail detail,
+    events.start_at start_at,
+    events.end_at end_at FROM users
+    INNER JOIN event_attendance ON event_attendance.user_id = users.id
+    INNER JOIN events ON events.id = event_attendance.event_id
+    WHERE event_attendance.is_attendance = TRUE
+    AND DATE(events.start_at) = DATE_ADD(CURRENT_DATE, INTERVAL 1 DAY)");
+    return $stmt->fetchAll();
+  }
 }

--- a/src/cruds/domains/Email.php
+++ b/src/cruds/domains/Email.php
@@ -12,25 +12,25 @@ class Email
     $subject = "イベント前日通知";
     $body = "本文";
     $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-    
+
     $body = <<<EOT
-    
+
     ${start_at}から${end_at}に${event}を開催します。
     詳細：
     ${detail}
 
     EOT;
     mb_send_mail($to, $subject, $body, $headers);
-    echo "メールを送信しました";
+    echo "メールを送信しました\n";
   }
 
   public function send_remind_mail($to,$event,$detail,$start_at,$end_at) {
     $subject = "イベント未回答通知";
     $body = "本文";
     $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-    
+
     $body = <<<EOT
-    
+
     ${start_at}から${end_at}に${event}を開催します。
     詳細：
     ${detail}
@@ -41,5 +41,5 @@ class Email
     mb_send_mail($to, $subject, $body, $headers);
     echo "メールを送信しました";
   }
-  
+
 }

--- a/src/modules/notification/send_before_attendee.php
+++ b/src/modules/notification/send_before_attendee.php
@@ -7,37 +7,15 @@ use cruds\Notification;
 
 $mail = new Email;
 $crud = new Notification($db);
-$attendees = $crud -> get_attendee();
-$before_attendance_events = $crud -> before_attendance_event();
-$tomrrow_events = $crud -> tomorrow_event();
-$to = "";
+$attendees = $crud->get_users_and_event_info_before_day();
 
-$before_attendee = array();
-// for($i = 0;$i <=$tomrrow_events[0]['count(*)'];$i++){
-//     $to .= $get_attendees['email'] . ",";
-// };
+
 foreach ($attendees as $attendee) {
-  $event_name = $attendee['name'];
+  $event_name = $attendee['event_name'];
   $email = $attendee['email'];
-  if(array_search($attendee['name'],$before_attendee)==False){
-    $before_attendee[$event_name] = array();
-    array_merge($before_attendee[$event_name],array($event_name=>$email));
-  }else{
-    array_merge($before_attendee[$event_name],array($event_name=>$email));
-  }
+  $detail = $attendee['detail'];
+  $start_at = $attendee['start_at'];
+  $end_at = $attendee['end_at'];
+
+  $mail->send_mail($email, $event_name, $detail, $start_at, $end_at);
 };
-
-// var_dump($before_attendee);
-// print_r($before_attendee);
-
-foreach($before_attendance_events as $before_attendance_event) {
-  $event = $before_attendance_event['name'];
-  $detail = $before_attendance_event['detail'];
-  $start_at = $before_attendance_event['start_at'];
-  $end_at = $before_attendance_event['end_at'];
-  $mail -> send_mail($to,$event,$detail,$start_at,$end_at);
-};
-
-// print_r($get_attendee);
-// print_r($tomrrow_events);
-// echo $tomrrow_events[0]['count(*)'];


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/25

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
前日に参加者にメールが送信されることを確認しました。
バッチを実行すると処理日がイベントの前日の場合参加者のみにメールを送付する
■バッチについて
ターミナルで以下コマンドで実行可能である
php send_before_attendee.php

## エビデンス
<img width="627" alt="スクリーンショット 2022-09-08 19 23 55" src="https://user-images.githubusercontent.com/72688676/189099140-e5ee85a8-517e-48aa-90b9-b93d745b4a27.png">
<img width="1710" alt="スクリーンショット 2022-09-08 19 24 30" src="https://user-images.githubusercontent.com/72688676/189099157-d04a853f-0b5a-4777-ad47-a601eb108ab5.png">
<!-- こちらに画面キャプチャを貼ってください -->
<img width="1710" alt="スクリーンショット 2022-09-08 19 24 33" src="https://user-images.githubusercontent.com/72688676/189099169-a418ca71-6391-4455-a719-25b44ed78aae.png">

