### PR TITLE
#33 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ slack通知

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -105,7 +105,9 @@ INSERT INTO events SET name='9/14イベント3', start_at='2022/09/14 21:00', en
 INSERT INTO events SET name='9/14イベント4', start_at='2022/09/14 21:00', end_at='2022/12/28 22:00';
 INSERT INTO events SET name='9/14イベント5', start_at='2022/09/14 21:00', end_at='2022/12/28 22:00';
 
-
+INSERT INTO event_attendance SET event_id=27, user_id=1;
+INSERT INTO event_attendance SET event_id=27, user_id=2;
+INSERT INTO event_attendance SET event_id=27, user_id=3;
 
 INSERT INTO event_attendance SET event_id=1, user_id=1, is_attendance=true;
 INSERT INTO event_attendance SET event_id=1, user_id=2, is_attendance=true;

--- a/src/cruds/Notification.php
+++ b/src/cruds/Notification.php
@@ -41,7 +41,7 @@ class Notification
     return $stmt -> fetchAll();
   }
 
-  public function before_unanswered_event() {
+  public function before_3days_event() {
     $stmt = $this->db ->prepare("SELECT name,detail,start_at,end_at FROM events WHERE DATE(start_at) = DATE_ADD(CURRENT_DATE,INTERVAL 3 DAY)");
     $stmt -> execute();
     return $stmt -> fetchAll();
@@ -57,6 +57,18 @@ class Notification
     INNER JOIN events ON events.id = event_attendance.event_id
     WHERE event_attendance.is_attendance = TRUE
     AND DATE(events.start_at) = DATE_ADD(CURRENT_DATE, INTERVAL 1 DAY)");
+    return $stmt->fetchAll();
+  }
+
+  public function get_unanswerd_3days_before_event()
+  {
+    $stmt = $this->db->query('SELECT users.username username, events.name event_name, events.start_at start_at,
+    events.end_at, events.detail detail FROM users
+    INNER JOIN event_attendance ON event_attendance.user_id = users.id
+    INNER JOIN events ON events.id = event_attendance.event_id
+    WHERE event_attendance.is_attendance = 2
+    AND DATE(events.start_at) = DATE_ADD(CURRENT_DATE, INTERVAL 3 DAY)');
+    $stmt->execute();
     return $stmt->fetchAll();
   }
 }

--- a/src/cruds/domains/Slack.php
+++ b/src/cruds/domains/Slack.php
@@ -41,7 +41,7 @@ class Slack
         $body = <<<EOT
     @${to}
     @channel
-    ${start_at}から${end_at}に${event}を開催します。
+    ${start_at}から${end_at}に${event}を開催します。未回答の方は期限までに回答をお願いします。
     詳細：
     ${detail}
 

--- a/src/modules/notification/send_unanswered_alluser.php
+++ b/src/modules/notification/send_unanswered_alluser.php
@@ -8,16 +8,16 @@ use cruds\Notification;
 $mail = new Email;
 $crud = new Notification($db);
 $all_users = $crud -> get_all_user();
-$before_unanswered_events = $crud -> before_unanswered_event();
+$before_3days_events = $crud -> before_3days_event();
 
 $to = "";
 foreach($all_users as $all_user) {
   $to .= $all_user['email'] . ",";
 };
-foreach($before_unanswered_events as $before_unanswered_event) {
-  $event = $before_unanswered_event['name'];
-  $detail = $before_unanswered_event['detail'];
-  $start_at = $before_unanswered_event['start_at'];
-  $end_at = $before_unanswered_event['end_at'];
+foreach($before_3days_events as $before_3days_event) {
+  $event = $before_3days_event['name'];
+  $detail = $before_3days_event['detail'];
+  $start_at = $before_3days_event['start_at'];
+  $end_at = $before_3days_event['end_at'];
   $mail -> send_remind_mail($to,$event,$detail,$start_at,$end_at);
 };

--- a/src/modules/notification/slack/send_unanswered_3days_before.php
+++ b/src/modules/notification/slack/send_unanswered_3days_before.php
@@ -1,0 +1,22 @@
+<?php
+require_once('../../../config.php');
+require_once('../../../cruds/Notification.php');
+require_once('../../../cruds/domains/Slack.php');
+
+use cruds\domains\Slack;
+use cruds\Notification;
+
+$crud = new Notification($db);
+$attendees = $crud->get_unanswerd_3days_before_event();
+
+$events = array();
+
+foreach ($attendees as $attendee) {
+    $email = $attendee['username'];
+    $event_name = $attendee['event_name'];
+    $detail = $attendee['detail'];
+    $start_at = $attendee['start_at'];
+    $end_at = $attendee['end_at'];
+
+    Slack::send_events_remind($email, $event_name, $detail, $start_at, $end_at);
+};


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/33


## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
バッチを実行したとき、未回答の人に3日前に通知が行くことを確認しました。

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="710" alt="スクリーンショット 2022-09-08 21 07 17" src="https://user-images.githubusercontent.com/72688676/189118689-9e872b94-6430-4332-bdb9-3469980c2f17.png">

<img width="1710" alt="スクリーンショット 2022-09-08 21 15 23" src="https://user-images.githubusercontent.com/72688676/189119353-e037bc02-5e88-4cbe-8ede-999064caf3e2.png">