### PR TITLE
#32 イベントの3日前に未回答となっている人のみにメール通知

### DIFF
--- a/src/cruds/Notification.php
+++ b/src/cruds/Notification.php
@@ -62,7 +62,7 @@ class Notification
 
   public function get_unanswerd_3days_before_event()
   {
-    $stmt = $this->db->query('SELECT users.username username, events.name event_name, events.start_at start_at,
+    $stmt = $this->db->query('SELECT users.email email, users.username username, events.name event_name, events.start_at start_at,
     events.end_at, events.detail detail FROM users
     INNER JOIN event_attendance ON event_attendance.user_id = users.id
     INNER JOIN events ON events.id = event_attendance.event_id

--- a/src/cruds/domains/Email.php
+++ b/src/cruds/domains/Email.php
@@ -39,7 +39,7 @@ class Email
     EOT;
 
     mb_send_mail($to, $subject, $body, $headers);
-    echo "メールを送信しました";
+    echo "メールを送信しました\n";
   }
 
 }

--- a/src/modules/notification/send_unanswered_3days_before.php
+++ b/src/modules/notification/send_unanswered_3days_before.php
@@ -1,0 +1,25 @@
+<?php
+require_once('../../cruds/Notification.php');
+require_once('../../cruds/domains/Email.php');
+
+use cruds\domains\Email;
+use cruds\Notification;
+
+$mail = new Email;
+$crud = new Notification($db);
+$all_users = $crud -> get_all_user();
+$attendees = $crud->get_unanswerd_3days_before_event();
+
+
+// var_dump($before_attendance_event);
+$to = "";
+foreach($all_users as $all_user) {
+  $to .= $all_user['email'] . ",";
+};
+foreach($attendees as $attendee) {
+  $event = $attendee['email'];
+  $detail = $attendee['detail'];
+  $start_at = $attendee['start_at'];
+  $end_at = $attendee['end_at'];
+  $mail -> send_remind_mail($to,$event,$detail,$start_at,$end_at);
+};


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
https://github.com/posse-ap/posse1-hackathon-202209-team2A/issues/32

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
バッチを実行するとイベント3日前にメールで未回答者に通知が行くことを確認しました。

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="668" alt="スクリーンショット 2022-09-08 21 30 13" src="https://user-images.githubusercontent.com/72688676/189122221-8b23384e-1e86-4801-b0ca-c293d1d05b8c.png">


<img width="1710" alt="スクリーンショット 2022-09-08 21 28 22" src="https://user-images.githubusercontent.com/72688676/189121992-c74d7cb4-d7d2-4eff-a257-09524dd5c86f.png">

<img width="1710" alt="スクリーンショット 2022-09-08 21 28 25" src="https://user-images.githubusercontent.com/72688676/189122062-cb31b656-c58e-4413-a1ad-5a7f315a53c3.png">
